### PR TITLE
fix: stabilize workspace bootstrap path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ uv run python -m uptempo
 - `LINEAR_API_KEY`
 - 내장 기본 워크플로우 `src/uptempo/runtime_assets/WORKFLOW.md`
 - 필요 시 `UPTEMPO_WORKFLOW_PATH`로 명시적 override
+- 필요 시 `UPTEMPO_WORKSPACE_SOURCE`로 워크스페이스 bootstrap source override
 - Codex 실행 환경
+
+기본 workspace bootstrap은 현재 Uptempo checkout을 명시적으로 clone합니다.
+다른 source를 쓰고 싶으면 `UPTEMPO_WORKSPACE_SOURCE`에 로컬 경로 또는 Git URL을 지정하세요.
 
 ## 동작 방식
 

--- a/scripts/bootstrap-workspace.sh
+++ b/scripts/bootstrap-workspace.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+source_repo="${UPTEMPO_WORKSPACE_SOURCE:-$repo_root}"
+
+if [[ -n "${UPTEMPO_WORKSPACE_SOURCE:-}" && "$source_repo" != /* ]]; then
+  candidate="$repo_root/$source_repo"
+  if [[ -e "$candidate" ]]; then
+    source_repo="$candidate"
+  fi
+fi
+
+clone_args=(--depth 1)
+if [[ -e "$source_repo" ]]; then
+  source_repo="$(cd "$source_repo" && pwd)"
+  clone_args+=(--no-local)
+fi
+
+git clone "${clone_args[@]}" "$source_repo" .

--- a/src/uptempo/__main__.py
+++ b/src/uptempo/__main__.py
@@ -3,16 +3,26 @@
 from __future__ import annotations
 
 import asyncio
+import os
+from pathlib import Path
 
 from uptempo.config.settings import Config
 from uptempo.orchestrator.loop import run_poll_loop
 from uptempo.workflow.loader import WorkflowLoader
-from uptempo.workflow.runtime import load_active_workflow
+from uptempo.workflow.runtime import WORKFLOW_OVERRIDE_ENV, load_active_workflow
+
+
+def _workflow_project_root() -> Path:
+    """Return the repo/project root used for resolving repo-relative hooks."""
+    workflow_override = os.getenv(WORKFLOW_OVERRIDE_ENV)
+    if workflow_override:
+        return Path(workflow_override).resolve().parent
+    return Path.cwd()
 
 
 async def _run() -> None:
     workflow = load_active_workflow(WorkflowLoader())
-    config = Config.from_frontmatter(workflow.config)
+    config = Config.from_frontmatter(workflow.config, project_root=_workflow_project_root())
     await run_poll_loop(config)
 
 

--- a/src/uptempo/config/settings.py
+++ b/src/uptempo/config/settings.py
@@ -38,6 +38,7 @@ class AgentConfig(BaseModel):
 
 class WorkspaceConfig(BaseModel):
     root: Path
+    project_root: Path | None = None
     hooks: dict[str, str] = Field(default_factory=dict)
 
 
@@ -49,7 +50,9 @@ class Config(BaseModel):
     workspace: WorkspaceConfig
 
     @classmethod
-    def from_frontmatter(cls, raw: dict[str, Any]) -> Config:
+    def from_frontmatter(
+        cls, raw: dict[str, Any], *, project_root: Path | None = None
+    ) -> Config:
         """Build a ``Config`` from the parsed YAML frontmatter dict.
 
         Resolves ``$ENV`` references against ``os.environ`` before validation.
@@ -65,6 +68,12 @@ class Config(BaseModel):
             merged_hooks = dict(workspace_hooks) if isinstance(workspace_hooks, dict) else {}
             merged_hooks.update(hooks)
             merged_workspace["hooks"] = merged_hooks
+            resolved["workspace"] = merged_workspace
+
+        if project_root is not None:
+            workspace = resolved.get("workspace")
+            merged_workspace = dict(workspace) if isinstance(workspace, dict) else {}
+            merged_workspace.setdefault("project_root", project_root)
             resolved["workspace"] = merged_workspace
         return cls(**resolved)
 

--- a/src/uptempo/runtime_assets/WORKFLOW.md
+++ b/src/uptempo/runtime_assets/WORKFLOW.md
@@ -19,7 +19,9 @@ workspace:
   root: ./workspaces
 hooks:
   after_create: |
-    git clone --depth 1 ../.. .
+    # Clone the current checkout by default.
+    # Set UPTEMPO_WORKSPACE_SOURCE to override with an explicit local path or Git URL.
+    scripts/bootstrap-workspace.sh
   before_remove: |
     # Uptempo workspaces are disposable local clones.
     true

--- a/src/uptempo/workspace/manager.py
+++ b/src/uptempo/workspace/manager.py
@@ -59,7 +59,11 @@ class WorkspaceManager:
 
     def __init__(self, config: Config) -> None:
         self._root = config.workspace.root.resolve()
-        self._project_root = self._root.parent
+        self._project_root = (
+            config.workspace.project_root.resolve()
+            if config.workspace.project_root is not None
+            else self._root.parent
+        )
         self._hooks = {}
         for name, command in config.workspace.hooks.items():
             stage = self._HOOK_STAGE_MAP.get(name)

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -65,6 +65,24 @@ class TestFromFrontmatter:
         assert cfg.workspace.root == Path("/opt/workspaces")
         assert cfg.workspace.hooks == {"pre_push": "lint.sh", "post_merge": "deploy.sh"}
 
+    def test_from_frontmatter_injects_project_root_when_provided(self):
+        raw = {"tracker": {"team_key": "UPT"}, "workspace": {"root": "/opt/workspaces"}}
+
+        cfg = Config.from_frontmatter(raw, project_root=Path("/repo/root"))
+
+        assert cfg.workspace.root == Path("/opt/workspaces")
+        assert cfg.workspace.project_root == Path("/repo/root")
+
+    def test_from_frontmatter_prefers_explicit_workspace_project_root(self):
+        raw = {
+            "tracker": {"team_key": "UPT"},
+            "workspace": {"root": "/opt/workspaces", "project_root": "/workflow/root"},
+        }
+
+        cfg = Config.from_frontmatter(raw, project_root=Path("/repo/root"))
+
+        assert cfg.workspace.project_root == Path("/workflow/root")
+
     def test_from_frontmatter_with_workflow_md_data(self):
         raw = {
             "tracker": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -44,3 +44,4 @@ async def test_run_loads_workflow_from_explicit_override(
     assert config.tracker.team_key == "UPT"
     assert config.tracker.poll_interval_ms == 12_000
     assert config.agent.codex_cmd == "codex --profile local"
+    assert config.workspace.project_root == workflow_path.parent.resolve()

--- a/tests/workflow/test_loader.py
+++ b/tests/workflow/test_loader.py
@@ -66,6 +66,11 @@ class TestLoad:
         assert isinstance(result, WorkflowDefinition)
         assert "workspace" in result.config
         assert "root" in result.config["workspace"]
+        assert result.config["hooks"]["after_create"] == (
+            "# Clone the current checkout by default.\n"
+            "# Set UPTEMPO_WORKSPACE_SOURCE to override with an explicit local path or Git URL.\n"
+            "scripts/bootstrap-workspace.sh\n"
+        )
 
     def test_load_valid_workflow(self, loader: WorkflowLoader, tmp_path: Path) -> None:
         wf_path = tmp_path / "WORKFLOW.md"

--- a/tests/workspace/test_bootstrap_script.py
+++ b/tests/workspace/test_bootstrap_script.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from typing import TYPE_CHECKING
+
+from tests.conftest import PROJECT_ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _init_git_repo(path: Path, marker_name: str, marker_value: str) -> None:
+    (path / "scripts").mkdir(parents=True, exist_ok=True)
+    shutil.copy2(
+        PROJECT_ROOT / "scripts" / "bootstrap-workspace.sh",
+        path / "scripts" / "bootstrap-workspace.sh",
+    )
+    (path / marker_name).write_text(marker_value, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test User",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "-qm",
+            "init",
+        ],
+        cwd=path,
+        check=True,
+    )
+    script_path = path / "scripts" / "bootstrap-workspace.sh"
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_bootstrap_script_clones_current_checkout_by_default(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root, "README.md", "from repo root\n")
+
+    workspace = repo_root / "workspaces" / "issue-1"
+    workspace.mkdir(parents=True)
+
+    subprocess.run(
+        [str(repo_root / "scripts" / "bootstrap-workspace.sh")],
+        cwd=workspace,
+        check=True,
+    )
+
+    assert (workspace / "README.md").read_text(encoding="utf-8") == "from repo root\n"
+    assert (workspace / ".git").is_dir()
+
+
+def test_bootstrap_script_honors_explicit_workspace_source(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _init_git_repo(repo_root, "README.md", "from repo root\n")
+
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    _init_git_repo(source_root, "SOURCE.txt", "from override\n")
+
+    workspace = repo_root / "workspaces" / "issue-1"
+    workspace.mkdir(parents=True)
+
+    env = os.environ.copy()
+    env["UPTEMPO_WORKSPACE_SOURCE"] = str(source_root)
+    subprocess.run(
+        [str(repo_root / "scripts" / "bootstrap-workspace.sh")],
+        cwd=workspace,
+        check=True,
+        env=env,
+    )
+
+    assert (workspace / "SOURCE.txt").read_text(encoding="utf-8") == "from override\n"
+    assert not (workspace / "README.md").exists()

--- a/tests/workspace/test_manager.py
+++ b/tests/workspace/test_manager.py
@@ -10,10 +10,20 @@ from uptempo.config.settings import Config, TrackerConfig, WorkspaceConfig
 from uptempo.workspace.manager import WorkspaceHookError, WorkspaceInfo, WorkspaceManager
 
 
-def _manager(tmp_path: Path, hooks: dict[str, str] | None = None) -> WorkspaceManager:
+def _manager(
+    tmp_path: Path,
+    hooks: dict[str, str] | None = None,
+    *,
+    workspace_root: Path | None = None,
+    project_root: Path | None = None,
+) -> WorkspaceManager:
     config = Config(
         tracker=TrackerConfig(team_key="UPT"),
-        workspace=WorkspaceConfig(root=tmp_path / "workspaces", hooks=hooks or {}),
+        workspace=WorkspaceConfig(
+            root=workspace_root or (tmp_path / "workspaces"),
+            project_root=project_root,
+            hooks=hooks or {},
+        ),
     )
     return WorkspaceManager(config)
 
@@ -117,6 +127,31 @@ class TestWorkspaceManager:
         script_path.chmod(0o755)
 
         manager = _manager(tmp_path, hooks={"after_create": "repo-hooks/after-create.sh"})
+
+        info = await manager.create("issue-5")
+
+        assert (info.path / "created.txt").read_text() == "ok"
+
+    async def test_relative_script_hook_uses_explicit_project_root_for_absolute_workspace_root(
+        self, tmp_path: Path
+    ):
+        project_root = tmp_path / "repo"
+        workspace_root = tmp_path / "external-workspaces"
+        script_path = project_root / "repo-hooks" / "after-create.sh"
+        script_path.parent.mkdir(parents=True)
+        workspace_root.mkdir(parents=True)
+        script_path.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'ok' > created.txt\n",
+            encoding="utf-8",
+        )
+        script_path.chmod(0o755)
+
+        manager = _manager(
+            tmp_path,
+            hooks={"after_create": "repo-hooks/after-create.sh"},
+            workspace_root=workspace_root,
+            project_root=project_root,
+        )
 
         info = await manager.create("issue-5")
 


### PR DESCRIPTION
## Summary\n- replace ambiguous WORKFLOW workspace bootstrap with an explicit bootstrap script\n- default workspace bootstrap to the current checkout with optional UPTEMPO_WORKSPACE_SOURCE override\n- inject workspace project_root so repo-relative hooks resolve even with absolute workspace roots\n\n## Testing\n- ruff check src/ tests/\n- pytest -q\n- mypy src/\n\nCloses #17